### PR TITLE
Support for GitLab

### DIFF
--- a/bin/keycutter
+++ b/bin/keycutter
@@ -42,7 +42,7 @@ source "${KEYCUTTER_ROOT}/lib/functions"
 #      with that account without crossing security boundaries.
 #
 #   2. Only use GitHub CLI from a device you trust with that GitHub account.
-#      E.g. Don't login to your personal GitHub account from a managed laptop. 
+#      E.g. Don't login to your personal GitHub account from a managed laptop.
 #
 
 usage() {
@@ -57,7 +57,7 @@ usage() {
     log "  --type     Optional. Which cryptographic key to use (ecdsa-sk, ed25519-sk). Default is ecdsa-sk."
     log
     log "SSH Keytag format: service_user@device"
-    log 
+    log
     log "  - service : Service this key is used with (e.g. 'github.com', 'aws', 'digitalocean')"
     log "  - user    : Service User this SSH Key authenticates as (e.g. 'alex')"
     log "  - device  : Device this ssh key resides on ( e.g. 'yubikey1', 'work-laptop', 'zfold5')"
@@ -122,38 +122,41 @@ keycutter-create() {
 
     local ssh_key_path="${KEYCUTTER_CONFIG_DIR}/keys/${ssh_keytag}" # Path SSH key will be written to
 
-    # Ensure config dirs exists wth correct perms
-    dir-ensure "$KEYCUTTER_CONFIG_DIR" 0700 
+    # Ensure config dirs exists with correct perms
+    dir-ensure "$KEYCUTTER_CONFIG_DIR" 0700
     dir-ensure "$(dirname "$ssh_key_path")" 0700
 
     # Create FIDO SSH Key for $ssh_keytag
     log "Generating FIDO SSH key: $ssh_key_path"
-    ssh-keygen -t "$ssh_key_type" -f "$ssh_key_path" -C "$ssh_keytag"  ${resident:+-O resident} # -N "" # Uncomment for no passphrase prompt
+    ssh-keygen -t "$ssh_key_type" -f "$ssh_key_path" -C "$ssh_keytag" ${resident:+-O resident} # -N "" # Uncomment for no passphrase prompt
     chmod 0600 "${ssh_key_path}.pub"
 
-    # If the SSH Keytag includes github.com 
-    local service="$(_ssh-keytag-service "$ssh_keytag")"
-    if [[ $service =~ github.com ]]; then
-        # Optionally add SSH key to GitHub for auth and commit/tag signing: $ssh_key_path
-        github-ssh-key-add "$ssh_key_path" "$ssh_keytag"
-        local demo_message="\nYou can SSH to GitHub by running:\n\n ssh -T $(_ssh-keytag-service-identity "$ssh_key_path")\n"
-        # Option to access GitHub when firewall blocks outbound port 22
-        prompt "Symlink key to enable ssh.github.com:443? [Y/n] "
-        read -n 1 -r
-        echo
-        if ! [[ $REPLY =~ ^[Nn]$ ]]; then
-            log "Creating symlink: ln -sf $ssh_key_path ${ssh_key_path/github.com/ssh.github.com}"
-            ln -sf "$ssh_key_path" "${ssh_key_path/github.com/ssh.github.com}"
-        fi
-    else 
-        log "DEBUG Skipping GitHub specific setup - SSH Keytag identity part doesn't contain 'github.com'."
-    fi
+    # Check the service and call the appropriate handler
+    check-service "$ssh_keytag" "$ssh_key_path"
 
     log "Success! Setup complete for key: $ssh_keytag"
 
     if [[ -n ${demo_message:-} ]]; then
-      echo -e "$demo_message" # Only for GitHub keys
+      echo -e "$demo_message" # Only for known services
     fi
+}
+
+check-service() {
+    local ssh_keytag="$1"
+    local ssh_key_path="$2"
+
+    local service="$(_ssh-keytag-service "$ssh_keytag")"
+    case "$service" in
+        github.com)
+            github-handle "$ssh_key_path" "$ssh_keytag"
+            ;;
+        gitlab.com)
+            gitlab-handle "$ssh_key_path" "$ssh_keytag"
+            ;;
+        *)
+            log "DEBUG Skipping specific setup - SSH Keytag identity part doesn't match known services."
+            ;;
+    esac
 }
 
 keycutter-authorized-keys() {

--- a/lib/functions
+++ b/lib/functions
@@ -2,6 +2,7 @@
 
 KEYCUTTER_ROOT="$(readlink -f "$(dirname -- "${BASH_SOURCE[0]:-${0:A}}")/../")"
 
+source "${KEYCUTTER_ROOT}/lib/gitlab"
 source "${KEYCUTTER_ROOT}/lib/github"
 source "${KEYCUTTER_ROOT}/lib/ssh"
 source "${KEYCUTTER_ROOT}/lib/utils"

--- a/lib/github
+++ b/lib/github
@@ -7,11 +7,11 @@ github-ssh-key-add() {
     local ssh_key_path="$1"
     local ssh_keytag="$2"
 
-    if [[ -z "$ssh_keytag" || -z "$ssh_key_path" ]]; then 
+    if [[ -z "$ssh_keytag" || -z "$ssh_key_path" ]]; then
         log "Error: ssh_keytag and ssh_key_path are required."
         return 1
     fi
-    
+
     prompt "Upload public key to GitHub for auth and commit signing using Github CLI? (Y/n) "
     read choice
     choice=${choice:-Y}
@@ -48,7 +48,7 @@ github-auth() {
 
     local gh_auth_token_scopes
     # If user is authenticated to GitHub
-    if gh_auth_token_scopes=$(gh auth status | grep scopes); then 
+    if gh_auth_token_scopes=$(gh auth status | grep scopes); then
       if [[ $gh_auth_token_scopes =~ 'admin:public_key' ]] && [[ $gh_auth_token_scopes =~ 'admin:ssh_signing_key' ]] ; then
         log >&2 "GitHub CLI: Required scopes are available."
       else
@@ -69,4 +69,19 @@ github-ssh-keys-authentication() {
 
 github-ssh-keys-signing() {
   github-ssh-keys | grep signing
+}
+
+github-handle() {
+    local ssh_key_path="$1"
+    local ssh_keytag="$2"
+
+    github-ssh-key-add "$ssh_key_path" "$ssh_keytag"
+    local demo_message="\nYou can SSH to GitHub by running:\n\n ssh -T $(_ssh-keytag-service-identity "$ssh_key_path")\n"
+    prompt "Symlink key to enable ssh.github.com:443? [Y/n] "
+    read -n 1 -r
+    echo
+    if ! [[ $REPLY =~ ^[Nn]$ ]]; then
+        log "Creating symlink: ln -sf $ssh_key_path ${ssh_key_path/github.com/ssh.github.com}"
+        ln -sf "$ssh_key_path" "${ssh_key_path/github.com/ssh.github.com}"
+    fi
 }

--- a/lib/gitlab
+++ b/lib/gitlab
@@ -1,0 +1,138 @@
+# GitLab functions
+
+# Function to log into GitLab using glab
+check-glab-cli() {
+    if ! command -v glab &> /dev/null; then
+        echo "glab could not be found. Please install glab CLI first."
+        exit 1
+    fi
+}
+
+gitlab-ssh-key-add() {
+    # XXX Replace if same SSH Keytag exists on GitHub
+
+    local ssh_key_path="$1"
+    local ssh_keytag="$2"
+
+    if [[ -z "$ssh_keytag" || -z "$ssh_key_path" ]]; then
+        log "Error: ssh_keytag and ssh_key_path are required."
+        return 1
+    fi
+
+    prompt "Upload public key to GitLab for auth using GitLab CLI? (Y/n) "
+    read choice
+    choice=${choice:-Y}
+    [[ $choice =~ ^[Yy]*$ ]] || return 1
+
+    check-glab-cli
+    if gitlab-auth; then
+        log "Add SSH authentication & signing key (${ssh_key_path}.pub) to GitLab"
+        glab ssh-key add "${ssh_key_path}.pub" -t "${ssh_keytag}"
+        log
+        log "Note: Enforce SSO-only authentication for Git and Dependency Proxy will require additional setup."
+    else
+        log "Error: Not uploading key to GitLab (no auth)"
+        return 1
+    fi
+}
+
+
+# Function to log into GitLab using glab
+gitlab-auth() {
+    check-glab-cli
+    glab auth status > /dev/null 2>&1
+    auth_status=$?
+
+    if [[ $auth_status -eq 0 ]]; then
+        logged_in_user=$(glab auth status 2>&1 | grep 'Logged in' | awk '{print $7}')
+        log "Logged in as ${logged_in_user}."
+        prompt "Do you want to switch to another GitLab account? (y/N): "
+        read -r choice
+
+        choice=${choice:-N}
+
+        if [[ $choice =~ ^[Yy]$ ]]; then
+            log " Info: Starting glab login process..."
+            prompt "Enter GitLab instance URL (default: https://gitlab.com): "
+            read -r GITLAB_URL
+            GITLAB_URL=${GITLAB_URL:-https://gitlab.com}
+            prompt "Enter your Personal Access Token (leave blank to use username/password): "
+            read -r GITLAB_TOKEN
+            echo
+
+            if [ -n "$GITLAB_TOKEN" ]; then
+                glab auth login --hostname "$GITLAB_URL" --token "$GITLAB_TOKEN"
+            else
+                prompt "Enter your GitLab Username: "
+                read -r GITLAB_USERNAME
+                prompt "Enter your GitLab Password: "
+                read -rs GITLAB_PASSWORD
+                log
+                glab auth login --hostname "$GITLAB_URL" --username "$GITLAB_USERNAME" --password "$GITLAB_PASSWORD"
+            fi
+
+            if [ $? -eq 0 ]; then
+                log "Logged into GitLab successfully."
+                return 0
+            else
+                log "Failed to log into GitLab. Please check your credentials and try again."
+                exit 1
+            fi
+        fi
+    else
+        log "warn Not logged into GitLab CLI."
+        # read -p "Do you want to log into a GitLab account? (y/N): " choice
+        log "prompt Do you want to log into a GitLab account? (y/N): "
+        read -r choice
+
+        choice=${choice:-N}
+
+        if [[ $choice =~ ^[Yy]$ ]]; then
+            log "info starting glab login process..."
+            log "prompt Enter GitLab instance URL (default: https://gitlab.com): "
+            read -r GITLAB_URL
+
+            GITLAB_URL=${GITLAB_URL:-https://gitlab.com}
+            read -sp "Enter your Personal Access Token (leave blank to use username/password): " GITLAB_TOKEN
+            echo
+
+            if [ -n "$GITLAB_TOKEN" ]; then
+                glab auth login --hostname "$GITLAB_URL" --token "$GITLAB_TOKEN"
+            else
+                read -p "Enter your GitLab Username: " GITLAB_USERNAME
+                read -sp "Enter your GitLab Password: " GITLAB_PASSWORD
+                echo
+                glab auth login --hostname "$GITLAB_URL" --username "$GITLAB_USERNAME" --password "$GITLAB_PASSWORD"
+            fi
+
+            if [ $? -eq 0 ]; then
+                log "Logged into GitLab successfully."
+                return 0
+            else
+                log "Failed to log into GitLab. Please check your credentials and try again."
+                exit 1
+            fi
+        fi
+    fi
+}
+
+
+gitlab-ssh-keys() {
+    gitlab-auth
+    glab ssh-key list
+}
+
+gitlab-handle() {
+    local ssh_key_path="$1"
+    local ssh_keytag="$2"
+
+    gitlab-ssh-key-add "$ssh_key_path" "$ssh_keytag"
+    local demo_message="\nYou can SSH to GitLab by running:\n\n ssh -T $(_ssh-keytag-service-identity "$ssh_key_path")\n"
+    prompt "Symlink key to enable ssh.gitlab.com:443? [Y/n] "
+    read -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Nn]$ ]]; then
+        log "Creating symlink: ln -sf $ssh_key_path ${ssh_key_path/gitlab.com/ssh.gitlab.com}"
+        ln -sf "$ssh_key_path" "${ssh_key_path/gitlab.com/ssh.gitlab.com}"
+    fi
+}


### PR DESCRIPTION
Proposing adding support for GitLab, this flows like:

```
$ keycutter create gitlab.com_lukeb@lukeb --type ed25519-sk                                                                                                                                            
❓ Append the current device to the SSH Keytag? (gitlab.com_lukeb@lukeb-versent). (Y/n) n
Proceeding with original ssh_keytag: gitlab.com_lukeb@lukeb
➕ Generating FIDO SSH key: /Users/lukeb/.ssh/keycutter/keys/gitlab.com_lukeb@lukeb
Generating public/private ed25519-sk key pair.
You may need to touch your authenticator to authorize key generation.
Enter PIN for authenticator:
You may need to touch your authenticator again to authorize key generation.
Enter passphrase (empty for no passphrase):
Enter same passphrase again:
Your identification has been saved in /Users/lukeb/.ssh/keycutter/keys/gitlab.com_lukeb@lukeb
Your public key has been saved in /Users/lukeb/.ssh/keycutter/keys/gitlab.com_lukeb@lukeb.pub
The key fingerprint is:
SHA256:... gitlab.com_lukeb@lukeb
The key's randomart image is:
+[ED25519-SK 256]-+
...
+----[SHA256]-----+
❓ Upload public key to GitLab for auth using GitLab CLI? (Y/n)  Y
cccccbgkughinLogged in as lukeburciu.
❓ Do you want to switch to another GitLab account? (y/N): N

➕ Add SSH authentication & signing key (/Users/lukeb/.ssh/keycutter/keys/gitlab.com_lukeb@lukeb.pub) to GitLab
✓ New SSH public key added to your account.

⚠️ Note: Enforce SSO-only authentication for Git and Dependency Proxy will require additional setup.
❓ Symlink key to enable ssh.gitlab.com:443? [Y/n] Y

➕ Creating symlink: ln -sf /Users/lukeb/.ssh/keycutter/keys/gitlab.com_lukeb@lukeb /Users/lukeb/.ssh/keycutter/keys/ssh.gitlab.com_lukeb@lukeb
✅ Success! Setup complete for key: gitlab.com_lukeb@lukeb
```