### PR TITLE
default `ssh_key_type` fix for unknown key type error on key creation

### DIFF
--- a/bin/keycutter
+++ b/bin/keycutter
@@ -78,7 +78,7 @@ keycutter-create() {
 
     # Set default values, override with command line options
     local ssh_key_resident=""
-    local ssh_key_type="$KEYCUTTER_SSH_KEY_TYPE"
+    local ssh_key_type="$KEYCUTTER_SSH_KEY_TYPE_SK"
     local ssh_keytag=""
 
     local KEYCUTTER_CONFIG_DIR="$(dirname "${KEYCUTTER_CONFIG}")"


### PR DESCRIPTION
An `unknown key type` error occurs during `keycutter create` - this PR fixes it by setting the `KEYCUTTER_SSH_KEY_TYPE_SK` as default for `local ssh_key_type="$KEYCUTTER_SSH_KEY_TYPE"`

Error:
```
$ keycutter create github.com_lukeburciu@lukeb                                                                                                                                                                                                                                                                                                                         <:
🔄 Modify Directory permissions: /Users/lukeb/.ssh/keycutter
🔄 Modify Directory permissions: /Users/lukeb/.ssh/keycutter/keys
➕ Generating FIDO SSH key: /Users/lukeb/.ssh/keycutter/keys/github.com_lukeburciu@lukeb
>>>> unknown key type <<<<
chmod: /Users/lukeb/.ssh/keycutter/keys/github.com_lukeburciu@lukeb.pub: No such file or directory
❓ Upload public key to GitHub for auth and commit signing using Github CLI? (Y/n)  ^
```

With this PR:
```
keycutter create github.com_lukeburciu@lukeb                                                                                                                                                                                                                                                                                                                                        <:
➕ Generating FIDO SSH key: /Users/lukeb/.ssh/keycutter/keys/github.com_lukeburciu@lukeb
Generating public/private ed25519-sk key pair.
You may need to touch your authenticator to authorize key generation.
Enter PIN for authenticator:
You may need to touch your authenticator again to authorize key generation.
Enter passphrase (empty for no passphrase):
Enter same passphrase again:
Your identification has been saved in /Users/lukeb/.ssh/keycutter/keys/github.com_lukeburciu@lukeb
Your public key has been saved in /Users/lukeb/.ssh/keycutter/keys/github.com_lukeburciu@lukeb.pub
The key fingerprint is:
SHA256:+... github.com_lukeburciu@lukeb
The key's randomart image is:
...
❓ Upload public key to GitHub for auth and commit signing using Github CLI? (Y/n)  Y
🛈 Tip: You can authorise GitHub CLI from a trusted device by visiting https://github.com/login/device
? Authenticate Git with your GitHub credentials? No

! First copy your one-time code: ABCD-1234
Press Enter to open github.com in your browser...
✓ Authentication complete.
- gh config set -h github.com git_protocol https
✓ Configured git protocol
✓ Logged in as lukeburciu
! You were already logged in to this account
GitHub CLI: Required scopes are available.
➕ Add SSH authentication key (/Users/lukeb/.ssh/keycutter/keys/github.com_lukeburciu@lukeb.pub) to GitHub
✓ Public key added to your account
➕ Add SSH signing key (/Users/lukeb/.ssh/keycutter/keys/github.com_lukeburciu@lukeb.pub) to GitHub
✓ Public key added to your account

⚠️  Note:  GitHub Organisations that enable or enforce SAML SSO will require additional setup.
❓ Symlink key to enable ssh.github.com:443? [Y/n]  n
✅ Success! Setup complete for key: github.com_lukeburciu@lukeb

You can SSH to GitHub by running:

 ssh -T github.com_lukeburciu

```