### PR TITLE
feat: Add HostName directive for GitHub CLI compatibility

### DIFF
--- a/ssh_config/keycutter/keycutter.conf
+++ b/ssh_config/keycutter/keycutter.conf
@@ -18,8 +18,11 @@ Host *github.com*
   IdentitiesOnly yes # Don't expose random public keys to GitHub.com.
   RequestTTY no      # GitHub does not (intentionally) provide shell access.
   # GitHub's solution to firewalls blocking SSH port 22
-  # HostName ssh.github.com 
+  # HostName ssh.github.com
   # Port 443
+
+Host github.com*
+  HostName github.com # Enable GitHub CLI to find a known host.
 
 Host *git.sr.ht*
   User git


### PR DESCRIPTION
## Summary

- Adds `HostName github.com` directive to SSH config for hosts matching `github.com*`
- Enables GitHub CLI (`gh`) to properly recognize SSH aliases like `github.com_mbailey` as valid GitHub hosts
- Preserves compatibility with `ssh.github.com*` firewall bypass setups

## Problem

When using keycutter with gitconfig `insteadOf` rules that rewrite GitHub URLs to SSH aliases (e.g., `git@github.com_mbailey:`), the GitHub CLI couldn't recognize these custom hosts as valid GitHub endpoints. Commands like `gh pr list` would fail.

## Solution

The fix adds a `HostName` directive that tells SSH (and tools that parse SSH config like `gh`) that hosts matching `github.com*` should resolve to `github.com`:

```sshconfig
Host github.com*
  HostName github.com # Enable GitHub CLI to find a known host.
```

This pattern:
- ✅ Matches `github.com`, `github.com_mbailey`, `github.com_work`, etc.
- ❌ Does NOT match `ssh.github.com_*` (preserving firewall bypass setups)

## Test plan

- [ ] Verify `gh pr list` works in a repo with `github.com_*` SSH alias
- [ ] Verify `ssh -G github.com_mbailey` shows `hostname github.com`
- [ ] Verify `ssh.github.com` setups still work if uncommented

Fixes: KC-14

🤖 Generated with [Claude Code](https://claude.com/claude-code)