### PR TITLE
fix: auto-fix SSH key file permissions before loading

### DIFF
--- a/ssh_config/keycutter/scripts/ssh-agent-ensure
+++ b/ssh_config/keycutter/scripts/ssh-agent-ensure
@@ -23,6 +23,12 @@ ssh-add -D 2> /dev/null
 shopt -s nullglob
 for key in "$agent_dir"/*@${KEYCUTTER_ORIGIN:-"$(hostname -s)"}; do
     if [[ -f "$key" && "$key" != *.pub ]]; then
+        # Fix permissions if too open (SSH requires 600 or stricter)
+        # Uses macOS native stat first, falls back to GNU/Linux stat syntax
+        current_perm=$(/usr/bin/stat -f %Lp "$key" 2>/dev/null || stat -c %a "$key" 2>/dev/null)
+        if [[ -n "$current_perm" && "$current_perm" != "600" ]]; then
+            chmod 600 "$key" 2>/dev/null || true
+        fi
         ssh-add "$key" &>/dev/null
     fi
 done


### PR DESCRIPTION
## Summary

- Fixes ssh-agent-ensure silently failing when key files have wrong permissions (e.g., 0644 instead of 0600)
- Auto-detects and fixes permissions before attempting ssh-add
- Cross-platform support (macOS and Linux stat syntax)

## Changes

- Added permission check before ssh-add in ssh-agent-ensure script
- Uses `/usr/bin/stat -f %Lp` on macOS, falls back to `stat -c %a` for Linux
- Graceful error handling - stat/chmod failures don't crash the script

## Testing

All tests pass on macOS:
- ✅ 644 → 600 (auto-fix)
- ✅ 755 → 600 (auto-fix)  
- ✅ 600 unchanged
- ✅ .pub files unchanged
- ✅ Keys load after fix

## Task

Closes KC-24

🤖 Generated with [Claude Code](https://claude.ai/code)